### PR TITLE
simple_bind - Support for secondary external zones

### DIFF
--- a/simple-bind/defaults/main.yaml
+++ b/simple-bind/defaults/main.yaml
@@ -29,4 +29,10 @@ simple_bind__forward_zones:
 #    extra_conf:
 #      - 'foo: bar'
 
+simple_bind__external_secondary_zones:
+#  - zone: example.com
+#    primaries: [192.168.1.1]
+#    extra_conf:
+#      - 'foo: bar'
+
 simple_bind__install_ferm_svc: false

--- a/simple-bind/templates/named.conf.local.j2
+++ b/simple-bind/templates/named.conf.local.j2
@@ -1,34 +1,66 @@
 // {{ ansible_managed }}
 
+acl internals {
+        localhost;
+        {{ internal_networks | ansible.utils.ipv4 }}
+        {{ internal_networks | ansible.utils.ipv6 }}
+};
+
+view internals {
+        match-clients { internals; };
+        allow-transfer { internals; };
+        allow-recursion { internals; };
+        
 {% for zone in simple_bind__forward_zones or [] -%}
-zone "{{ zone.zone }}" {
-        type forward;
-        forward {{ zone.forward | default('first') }};
-        forwarders {
+        zone "{{ zone.zone }}" {
+                type forward;
+                forward {{ zone.forward | default('first') }};
+                forwarders {
 {% for forwarder in zone.get('forwarders') or [] %}
-            {{ forwarder }};
+                    {{ forwarder }};
 {% endfor -%}
-        };
-        file "db.{{ zone.zone }}";
+                };
+                file "db.internal{{ zone.zone }}";
 {% for extra in zone.get('extra_conf') or [] %}
-            {{ extra }};
+                    {{ extra }};
 {% endfor %}
 };
 
 {% endfor -%}
 
 {% for zone in simple_bind__secondary_zones or [] -%}
-zone "{{ zone.zone }}" {
-        type slave;
-        masters {
+        zone "{{ zone.zone }}" {
+            type slave;
+            masters {
 {% for primary in zone.get('primaries') or [] %}
-            {{ primary }};
+                    {{ primary }};
+{% endfor %}
+            };
+        file "db.internal.{{ zone.zone }}";
+{% for extra in zone.get('extra_conf') or [] %}
+        {{ extra }};
 {% endfor %}
         };
-        file "db.{{ zone.zone }}";
-{% for extra in zone.get('extra_conf') or [] %}
-            {{ extra }};
+
 {% endfor %}
 };
 
+view externals {
+        match-clients { any; };
+        allow-transfer {"none"; };
+        recursion no;
+
+{% for zone in simple_bind__external_secondary_zones or [] -%}
+        zone "{{ zone.zone }}" {
+            type slave;
+            masters {
+{% for primary in zone.get('primaries') or [] %}
+                    {{ primary }};
 {% endfor %}
+            };
+        file "db.{{ zone.zone }}";
+{% for extra in zone.get('extra_conf') or [] %}
+        {{ extra }};
+{% endfor %}
+        };
+};

--- a/simple-bind/templates/named.conf.local.j2
+++ b/simple-bind/templates/named.conf.local.j2
@@ -10,7 +10,7 @@ view internals {
         match-clients { internals; };
         allow-transfer { internals; };
         allow-recursion { internals; };
-        
+
 {% for zone in simple_bind__forward_zones or [] -%}
         zone "{{ zone.zone }}" {
                 type forward;
@@ -20,9 +20,10 @@ view internals {
                     {{ forwarder }};
 {% endfor -%}
                 };
-                file "db.internal{{ zone.zone }}";
+                file "db.internal.{{ zone.zone }}";
 {% for extra in zone.get('extra_conf') or [] %}
-                    {{ extra }};
+                {{ extra }};
+        };
 {% endfor %}
 };
 
@@ -30,12 +31,12 @@ view internals {
 
 {% for zone in simple_bind__secondary_zones or [] -%}
         zone "{{ zone.zone }}" {
-            type slave;
-            masters {
+                type slave;
+                masters {
 {% for primary in zone.get('primaries') or [] %}
-                    {{ primary }};
+                        {{ primary }};
 {% endfor %}
-            };
+        };
         file "db.internal.{{ zone.zone }}";
 {% for extra in zone.get('extra_conf') or [] %}
         {{ extra }};
@@ -58,7 +59,7 @@ view externals {
                     {{ primary }};
 {% endfor %}
             };
-        file "db.{{ zone.zone }}";
+        file "db.external.{{ zone.zone }}";
 {% for extra in zone.get('extra_conf') or [] %}
         {{ extra }};
 {% endfor %}


### PR DESCRIPTION
This is an attempt to expand the configuration so that it knows where the queries come from and can handle only external secondary zones.