### PR TITLE
Add documentation for TOML filter plugin

### DIFF
--- a/plugins/filter/from_toml.yaml
+++ b/plugins/filter/from_toml.yaml
@@ -1,0 +1,30 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+DOCUMENTATION:
+  name: from_toml
+  author: Dato Simó
+  version_added: 2.0.0
+  short_description: Convert TOML string into variable structure
+  description:
+    - Converts a TOML string representation into an equivalent structured
+      Ansible variable.
+  notes:
+    - This filter functions as a wrapper to the L(Python TOML library,
+      https://pypi.org/project/toml/)'s C(toml.loads) function.
+  options:
+    _input:
+      description: A TOML string.
+      type: string
+      required: true
+
+EXAMPLES: |
+  # variable from string variable containing a TOML document
+  {{ my_toml_string | from_toml }}
+
+  # variable from string TOML document
+  {{ 'a = true\nb = 54\nc = [ 1, 2, 3 ]\n' | from_toml }}
+
+RETURN:
+  _value:
+    description: The variable resulting from deserializing the TOML document.
+    type: raw

--- a/plugins/filter/to_toml.yaml
+++ b/plugins/filter/to_toml.yaml
@@ -1,0 +1,26 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+DOCUMENTATION:
+  name: to_toml
+  author: Dato Simó
+  version_added: 2.0.0
+  short_description: Convert variable to TOML string
+  description:
+    - Converts an Ansible variable into a TOML string representation.
+  notes:
+    - This filter functions as a wrapper to the L(Python TOML library,
+      https://pypi.org/project/toml/)'s C(toml.dumps) function.
+  options:
+    _input:
+      description: A variable or expression that returns a data structure.
+      type: raw
+      required: true
+
+EXAMPLES: |
+  # dump variable in a template to create a TOML document
+  {{ my_complex_var | to_toml }}
+
+RETURN:
+  _value:
+    description: The TOML serialized string representing the input.
+    type: string


### PR DESCRIPTION
```
$ ansible-doc -t filter tina_pm.common.to_toml
> FILTER tina_pm.common.to_toml (.../.collections/ansible_collections/tina_pm/common/plugins/filter/to_toml.yaml)>

  Converts an Ansible variable into a TOML string representation.

OPTIONS (red indicates it is required):

   _input  A variable or expression that returns a data structure.
        type: raw

NOTES:
      * This filter functions as a wrapper to the Python TOML library
        <https://pypi.org/project/toml/>'s `toml.dumps'
        function.

AUTHOR: Dato Simó

NAME: to_toml

EXAMPLES:
# dump variable in a template to create a TOML document
{{ my_complex_var | to_toml }}

RETURN VALUES:

   _value  The TOML serialized string representing the input.
        type: string
```