### PR TITLE
`users`: Tighten permissions on home templates

### DIFF
--- a/roles/users/defaults/main.yaml
+++ b/roles/users/defaults/main.yaml
@@ -48,6 +48,19 @@ users__create_groups: []
 # to each users' home directory.
 users__home_dir_templates: home_templates/
 
+# users__home_dir_templates_copy_xbit: Preserve executable bit in files
+# copied.
+users__home_dir_templates_copy_xbit: true
+
+# users__home_dir_templates_force_file_mode: Force mode bits for regular files
+# copied. Note: this might be altered if `users__home_dir_templates_copy_xbit`
+# is true.
+users__home_dir_templates_force_file_mode: '0644'
+
+# users__home_dir_templates_force_dir_mode: Force mode bits for directories
+# created.
+users__home_dir_templates_force_dir_mode: '0755'
+
 # users__root_mail_forward: Forward root email to this address.
 users__root_mail_forward: ~
 

--- a/roles/users/tasks/user.yaml
+++ b/roles/users/tasks/user.yaml
@@ -43,7 +43,7 @@
 - name: '[{{ user.name }}] set-up user home: directories'
   ansible.builtin.file:
     path: '{{ user.home }}/{{ item.path }}'
-    mode: '{{ item.mode }}'
+    mode: '{{ _usr_home_dmode }}'
     owner: '{{ user.name }}'
     group: '{{ user.name }}'
     state: directory
@@ -55,7 +55,9 @@
   ansible.builtin.copy:
     src: '{{ item.src }}'
     dest: '{{ user.home }}/{{ item.path }}'
-    mode: '{{ item.mode }}'
+    # Force mode if requested; then add *all* executable bits if *any* is set
+    # in the source, and requested.
+    mode: '{{ _usr_home_fmode }}'
     owner: '{{ user.name }}'
     group: '{{ user.name }}'
   with_community.general.filetree: '{{
@@ -66,7 +68,9 @@
   ansible.builtin.template:
     src: '{{ item.src }}'
     dest: '{{ user.home }}/{{ item.path | regex_replace("\.j2$", "") }}'
-    mode: '{{ item.mode }}'
+    # Force mode if requested; then add *all* executable bits if *any* is set
+    # in the source, and requested.
+    mode: '{{ _usr_home_fmode }}'
     owner: '{{ user.name }}'
     group: '{{ user.name }}'
   with_community.general.filetree: '{{
@@ -77,7 +81,7 @@
   ansible.builtin.file:
     src: '{{ item.src }}'
     path: '{{ user.home }}/{{ item.path }}'
-    mode: '{{ item.mode }}'
+    # Always use default mode.
     owner: '{{ user.name }}'
     group: '{{ user.name }}'
     state: link

--- a/roles/users/vars/main.yaml
+++ b/roles/users/vars/main.yaml
@@ -1,0 +1,32 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+
+# Pre-processing and validation of parameters.
+
+# Note 1: these can only be used inside a filetree loop, as they use the
+# `item.mode` variable.
+# Note 2: Ansible converts all numeric values to strings when templating and
+# parsing variable values (but keeps booleans, lists, and dicts as native
+# objects), so avoid using temporary variables for passing numeric values.
+
+# True if item is executable, an *and* the user requested copying the
+# executable bit.
+_usr_home_xfile: |-
+  {{
+    (item.mode | int(base=8)).__and__(0o111) != 0 and
+    users__home_dir_templates_copy_xbit
+  }}
+_usr_home_fmode: |-
+  {{
+    '0%o' % (
+      (users__home_dir_templates_force_file_mode or item.mode) | int(base=8)
+    ).__or__(
+      0o111 if _usr_home_xfile else 0
+    )
+  }}
+_usr_home_dmode: |-
+  {{
+    '0%o' % (
+      (users__home_dir_templates_force_dir_mode or item.mode) | int(base=8)
+    )
+  }}


### PR DESCRIPTION
This change adds options to control the permissions on files copied to users' home directories.

Closes #34