### PR TITLE
New 'cached' lookup plugin

### DIFF
--- a/plugins/lookup/cached.py
+++ b/plugins/lookup/cached.py
@@ -1,0 +1,82 @@
+# Memory-only caching lookup plugin
+# Based on https://pypi.org/project/ansible-cached-lookup/
+# Copyright 2018 GoodRx
+# MIT licensed
+"""
+An Ansible lookup plugin that caches the results of any other lookup, most
+useful in group/host vars.
+
+By default, Ansible evaluates any lookups in a group/host var whenever the var
+is accessed. For example, given a group/host var:
+
+.. code-block:: yaml
+
+    content: '{{ lookup("pipe", "a-very-slow-command") }}'
+
+any tasks that access ``content`` (e.g. in a template) will re-evaluate
+the lookup, which adds up very quickly.
+
+.. seealso:: :attr:`.DOCUMENTATION`, :attr:`.EXAMPLES`, `ansible/ansible#9623
+    <https://github.com/ansible/ansible/issues/9623>`_
+"""
+from functools import lru_cache
+from threading import Lock
+
+from ansible.errors import AnsibleError
+from ansible.plugins.loader import lookup_loader
+from ansible.plugins.lookup import LookupBase
+from ansible.utils.display import Display
+
+__version__ = "1.0.0"
+
+
+DOCUMENTATION = """
+lookup: cached
+short_description: cache the result of a lookup
+description:
+  - Run a lookup and cache the result for the duration of the play. This is
+    most useful for lookups in group/host vars, which are typically
+    re-evaluated every time they are used
+options:
+  _terms:
+    description: the lookup and any arguments
+    required: True
+"""
+
+EXAMPLES = """
+group_var1: '{{ lookup("cached", "pipe", "a-very-slow-command") }}'
+"""
+
+
+display = Display()
+
+
+class LookupModule(LookupBase):
+    _cache = {}
+    _lock = Lock()
+
+    def _lookup(self, lookup_name, terms, variables, **kwargs):
+        lookup = lookup_loader.get(
+            lookup_name, loader=self._loader, templar=self._templar
+        )
+        if lookup is None:
+            raise AnsibleError('lookup plugin (%s) not found' % lookup_name)
+
+        return lookup.run(terms, variables=variables, **kwargs)
+
+    def run(self, terms, variables=None, **kwargs):
+        lookup_name, terms = terms[0], terms[1:]
+        key = repr(terms)
+
+        with self._lock:
+          try:
+            result = self._cache[key]
+            display.verbose('cache hit: %s => %s' % (key, result))
+            return result
+          except KeyError:
+            pass
+
+        result = self._lookup(lookup_name, terms, variables, **kwargs)
+        with self._lock:
+            self._cache[key] = result
+        return result


### PR DESCRIPTION
This plugin allows caching results of slow lookups, e.g. passwordstore lookups.