### PR TITLE
More bind improvements

### DIFF
--- a/roles/simple_bind/defaults/main.yaml
+++ b/roles/simple_bind/defaults/main.yaml
@@ -14,6 +14,7 @@ simple_bind__options:
 #    - 'foo: bar'
 
 simple_bind__includes:
+  - /etc/bind/named.conf.default-zones
   - /etc/bind/zones.rfc1918
 
 simple_bind__secondary_zones:

--- a/roles/simple_bind/defaults/main.yaml
+++ b/roles/simple_bind/defaults/main.yaml
@@ -19,6 +19,10 @@ simple_bind__includes:
 #  - named.conf.default-zones
 #  - zones.rfc1918
 
+simple_bind__acls:
+#  myacl:
+#    - 192.168.0.0/16
+
 simple_bind__views:
   - name: default
     match_clients:

--- a/roles/simple_bind/defaults/main.yaml
+++ b/roles/simple_bind/defaults/main.yaml
@@ -37,6 +37,11 @@ simple_bind__views:
       - named.conf.default-zones
       - zones.rfc1918
 
+simple_bind__in_view_zones:
+#  - zone: example.com
+#    view: default
+#    in_view: external
+
 simple_bind__primary_zones:
 #  - zone: example.com
 #    view: default

--- a/roles/simple_bind/defaults/main.yaml
+++ b/roles/simple_bind/defaults/main.yaml
@@ -16,17 +16,33 @@ simple_bind__options:
 #    - 'foo: bar'
 
 simple_bind__includes:
-  - named.conf.default-zones
-  - zones.rfc1918
+#  - named.conf.default-zones
+#  - zones.rfc1918
+
+simple_bind__views:
+  - name: default
+    match_clients:
+      - any
+    allow_transfer:
+      - any
+    recursion: true
+    allow_recursion:
+      - localhost
+      - localnets
+    includes:
+      - named.conf.default-zones
+      - zones.rfc1918
 
 simple_bind__secondary_zones:
 #  - zone: example.com
+#    view: default
 #    primaries: [192.168.1.1]
 #    extra_conf:
 #      - 'foo: bar'
 
 simple_bind__forward_zones:
 #  - zone: example.com
+#    view: default
 #    forwarders: [192.168.1.1]
 #    forward: only
 #    extra_conf:

--- a/roles/simple_bind/defaults/main.yaml
+++ b/roles/simple_bind/defaults/main.yaml
@@ -1,6 +1,8 @@
 ---
 # vim:ts=2:sw=2:et:ai:sts=2
 
+simple_bind__config_dir: /etc/bind
+
 simple_bind__options:
   forward: first
   forwarders: []
@@ -14,8 +16,8 @@ simple_bind__options:
 #    - 'foo: bar'
 
 simple_bind__includes:
-  - /etc/bind/named.conf.default-zones
-  - /etc/bind/zones.rfc1918
+  - named.conf.default-zones
+  - zones.rfc1918
 
 simple_bind__secondary_zones:
 #  - zone: example.com

--- a/roles/simple_bind/defaults/main.yaml
+++ b/roles/simple_bind/defaults/main.yaml
@@ -37,6 +37,16 @@ simple_bind__views:
       - named.conf.default-zones
       - zones.rfc1918
 
+simple_bind__primary_zones:
+#  - zone: example.com
+#    view: default
+#    src_type: string  # Or 'template', 'file'
+#    src: |
+#      @ IN SOA example.com. root.example.com. ( 1 604800 86400 2419200 604800 )
+#      @ IN NS ns1.example.com.
+#    extra_conf:
+#      - 'foo: bar'
+
 simple_bind__secondary_zones:
 #  - zone: example.com
 #    view: default

--- a/roles/simple_bind/handlers/main.yaml
+++ b/roles/simple_bind/handlers/main.yaml
@@ -3,7 +3,7 @@
 - name: _tina_validate_bind_conf
   ansible.builtin.command:
     cmd: named-checkconf
-    chdir: /etc/bind
+    chdir: '{{ _sbind_confdir }}'
   changed_when: false
 
 - name: _tina_reload_bind

--- a/roles/simple_bind/meta/argument_specs.yml
+++ b/roles/simple_bind/meta/argument_specs.yml
@@ -160,6 +160,13 @@ argument_specs:
             choices: [string, template, file]
             default: string
 
+          template_vars:
+            description:
+              - Additional variables for templating.
+              - The variables C(ZONE) and C(VIEW) are always available.
+              - Ignored unless C(src_type == 'template').
+            type: dict
+
           extra_conf: *extra_conf
 
       simple_bind__secondary_zones:

--- a/roles/simple_bind/meta/argument_specs.yml
+++ b/roles/simple_bind/meta/argument_specs.yml
@@ -1,0 +1,187 @@
+# vim:ts=2:sw=2:et:ai:sts=2
+---
+argument_specs:
+  main:
+    short_description: Install and configure Bind9 DNS server
+    author:
+      - Martina Ferrari
+    options:
+      simple_bind__config_dir:
+        description:
+          Root configuration directory.
+        type: path
+        default: /etc/bind
+
+      simple_bind__options:
+        description: C(options) block in C(named.conf.options)
+        type: dict
+        options:
+          forward: &forward
+            description:
+              Allow or disallow fallback to recursion if forwarding failed.
+            type: str
+            choices: [first, only]
+            default: first
+
+          forwarders: &forwarders
+            description: Hosts to forward queries to.
+            type: list
+            elements: str
+            default: []
+
+          listen_on: &listen_on
+            description: IPv4 addresses on which to listen for DNS queries.
+            type: list
+            elements: dict
+            default:
+              - port: 53
+                match_list: [any]
+            options:
+              port:
+                description: Port number
+                type: int
+              match_list:
+                description: Address match elements
+                type: list
+                elements: str
+                default: [any]
+
+          listen_on_v6:
+            <<: *listen_on
+            description: IPv6 addresses on which to listen for DNS queries.
+
+          extra_conf: &extra_conf
+            description:
+              List of free-form configuration directives.
+            type: list
+            elements: str
+
+      simple_bind__includes: &includes
+        description:
+          - List of files to include in the global scope.
+          - Relative paths are resolved relative to C(simple_bind__config_dir).
+        type: list
+        elements: path
+
+      simple_bind__acls:
+        description:
+          Assign a symbolic name to an address match list.
+        type: dict
+
+      simple_bind__views:
+        description:
+          Enable answering queries differently depending on client IP address.
+        type: list
+        elements: dict
+        default:
+          - name: default
+            match_clients:
+              - any
+            allow_transfer:
+              - any
+            recursion: true
+            allow_recursion:
+              - localhost
+              - localnets
+            includes:
+              - named.conf.default-zones
+              - zones.rfc1918
+        options:
+          name:
+            description: View name.
+            type: str
+            required: true
+
+          match_clients:
+            description:
+              Client IP addresses or C(acl)s that will be served by this view.
+            type: str
+            required: true
+
+          allow_transfer:
+            description:
+              Client IP addresses or C(acl)s allowed to transfer zones.
+            type: list
+            elements: str
+
+          recursion:
+            description: Allow recursion and caching.
+            type: bool
+            default: true
+
+          allow_recursion:
+            description:
+              Client IP addresses or C(acl)s allowed to make recursive queries.
+            type: list
+            elements: str
+
+          includes: *includes
+
+      simple_bind__primary_zones:
+        description: The main copy of the data for a zone.
+        type: list
+        elements: dict
+        options:
+          zone: &zone
+            description: Zone name.
+            type: str
+            required: true
+
+          view: &view
+            description: View that serves this zone.
+            type: str
+            default: default
+
+          src:
+            description:
+              - Content of the zone file.
+              - Accepts textual zone content, or a file name to copy or
+                template (according on the C(src_type) option).
+            type: str
+            required: true
+
+          src_type:
+            description: Type of source content.
+            type: str
+            choices: [string, template, file]
+            default: string
+
+          extra_conf: *extra_conf
+
+      simple_bind__secondary_zones:
+        description:
+          Duplicate of the data for a zone, transferred from a primary server.
+        type: list
+        elements: dict
+        options:
+          zone: *zone
+          view: *view
+
+          primaries:
+            description: Primary servers to transfer the zone data from.
+            type: list
+            elements: str
+            required: true
+
+          extra_conf: *extra_conf
+
+      simple_bind__forward_zones:
+        description: Configure forwarding on a per-domain basis.
+        type: list
+        elements: dict
+        options:
+          zone: *zone
+          view: *view
+          forwarders: *forwarders
+          forward: *forward
+          extra_conf: *extra_conf
+
+      simple_bind__install_ferm_svc:
+        description: If true, install ferm configuration file.
+        type: bool
+        default: false
+
+      simple_bind__ferm_allow_from:
+        description: Optionally limit access by a list of IP addresses/blocks.
+        type: list
+        elements: str

--- a/roles/simple_bind/meta/argument_specs.yml
+++ b/roles/simple_bind/meta/argument_specs.yml
@@ -83,6 +83,7 @@ argument_specs:
             allow_recursion:
               - localhost
               - localnets
+            in_view_zones: []
             includes:
               - named.conf.default-zones
               - zones.rfc1918
@@ -117,8 +118,8 @@ argument_specs:
 
           includes: *includes
 
-      simple_bind__primary_zones:
-        description: The main copy of the data for a zone.
+      simple_bind__in_view_zones:
+        description: A zone copied from a previously defined view.
         type: list
         elements: dict
         options:
@@ -131,6 +132,19 @@ argument_specs:
             description: View that serves this zone.
             type: str
             default: default
+
+          in_view:
+            description: View that defines this zone.
+            type: str
+            required: true
+
+      simple_bind__primary_zones:
+        description: The main copy of the data for a zone.
+        type: list
+        elements: dict
+        options:
+          zone: *zone
+          view: *view
 
           src:
             description:

--- a/roles/simple_bind/tasks/main.yaml
+++ b/roles/simple_bind/tasks/main.yaml
@@ -17,7 +17,7 @@
 - name: Install configuration files
   ansible.builtin.template:
     src: '{{ item }}.j2'
-    dest: /etc/bind/{{ item }}
+    dest: '{{ _sbind_confdir }}/{{ item }}'
     owner: root
     group: root
     mode: '0644'

--- a/roles/simple_bind/tasks/main.yaml
+++ b/roles/simple_bind/tasks/main.yaml
@@ -29,6 +29,27 @@
     - _tina_validate_bind_conf
     - _tina_reload_bind
 
+- name: Create view directories for zone files
+  ansible.builtin.file:
+    state: directory
+    dest: '{{ item }}'
+    owner: root
+    group: root
+    mode: '0755'
+  loop: '{{ _sbind_zone_dirs }}'
+
+- name: Install zone files
+  ansible.builtin.copy:
+    content: '{{ item.content }}'
+    dest: '{{ item.dest }}'
+    owner: root
+    group: root
+    mode: '0644'
+  loop: '{{ _sbind_zone_files }}'
+  notify:
+    - _tina_validate_bind_conf
+    - _tina_reload_bind
+
 - name: Install ferm configuration
   ansible.builtin.include_role:
     name: ferm_svc

--- a/roles/simple_bind/templates/macros.j2
+++ b/roles/simple_bind/templates/macros.j2
@@ -12,6 +12,7 @@
 {%- endfilter %}
 {%- endmacro %}
 
-{% macro arg_path(path) %}
-{{ path | ansible.builtin.to_json }}
+{# All arguments are joined to construct a path. #}
+{% macro arg_path() %}
+{{ varargs | ansible.builtin.path_join | ansible.builtin.to_json }}
 {%- endmacro %}

--- a/roles/simple_bind/templates/macros.j2
+++ b/roles/simple_bind/templates/macros.j2
@@ -1,0 +1,13 @@
+{% macro arg_bool(value) %}
+{{ 'yes' if value else 'no' }}
+{%- endmacro %}
+
+{% macro arg_list(value, indent=0, indent_incr=2) %}
+{% filter indent(width=indent) %}
+{
+{% for item in value %}
+{{ ' ' * indent_incr }}{{ item }};
+{% endfor %}
+}
+{%- endfilter %}
+{%- endmacro %}

--- a/roles/simple_bind/templates/macros.j2
+++ b/roles/simple_bind/templates/macros.j2
@@ -11,3 +11,7 @@
 }
 {%- endfilter %}
 {%- endmacro %}
+
+{% macro arg_path(path) %}
+{{ path | ansible.builtin.to_json }}
+{%- endmacro %}

--- a/roles/simple_bind/templates/named.conf.j2
+++ b/roles/simple_bind/templates/named.conf.j2
@@ -1,9 +1,9 @@
+{% from 'macros.j2' import arg_path %}
+{# #}
 // {{ ansible_managed }}
+//
 // This is the primary configuration file for the BIND DNS server named.
 
-include "/etc/bind/named.conf.options";
-include "/etc/bind/named.conf.local";
-include "/etc/bind/named.conf.default-zones";
-{% for file in simple_bind__includes or [] %}
-include "{{ file }}";
+{% for file in _sbind_includes %}
+include {{ arg_path(file) }};
 {% endfor %}

--- a/roles/simple_bind/templates/named.conf.j2
+++ b/roles/simple_bind/templates/named.conf.j2
@@ -5,5 +5,5 @@
 // This is the primary configuration file for the BIND DNS server named.
 
 {% for file in _sbind_includes %}
-include {{ arg_path(file) }};
+include {{ arg_path(_sbind_confdir, file) }};
 {% endfor %}

--- a/roles/simple_bind/templates/named.conf.local.j2
+++ b/roles/simple_bind/templates/named.conf.local.j2
@@ -1,30 +1,25 @@
+{% from 'macros.j2' import arg_bool, arg_list %}
+{# #}
 // {{ ansible_managed }}
 
-{% for zone in simple_bind__forward_zones or [] -%}
+{% for zone in simple_bind__forward_zones or [] %}
 zone "{{ zone.zone }}" {
   type forward;
   forward {{ zone.forward | default('first') }};
-  forwarders {
-{% for forwarder in zone.get('forwarders') or [] %}
-    {{ forwarder }};
-{% endfor -%}
-  };
+  forwarders {{ arg_list(zone.get('forwarders') or [], indent=2) }};
   file "db.{{ zone.zone }}";
 {% for extra in zone.get('extra_conf') or [] %}
   {{ extra }};
 {% endfor %}
 };
 
-{% endfor -%}
-
-{% for zone in simple_bind__secondary_zones or [] -%}
+{% endfor %}
+{% for zone in simple_bind__secondary_zones or [] %}
 zone "{{ zone.zone }}" {
   type {{ _sbind_term.secondary }};
-  {{ _sbind_term.primaries }} {
-{% for primary in zone.get('primaries') or [] %}
-    {{ primary }};
-{% endfor %}
-  };
+  {{ _sbind_term.primaries }} {{
+    arg_list(zone.get('primaries') or [], indent=2)
+  }};
   file "db.{{ zone.zone }}";
 {% for extra in zone.get('extra_conf') or [] %}
   {{ extra }};

--- a/roles/simple_bind/templates/named.conf.local.j2
+++ b/roles/simple_bind/templates/named.conf.local.j2
@@ -72,7 +72,7 @@ view {{ view.name }} {
     {{ _sbind_term.primaries }} {{
       arg_list(zone.get('primaries') or [], indent=4)
     }};
-    file "db.{{ zone.zone }}";
+    file "db.{{ zone.zone }}.{{ zone.view }}";
 {% for extra in zone.get('extra_conf') or [] %}
     {{ extra }};
 {% endfor %}

--- a/roles/simple_bind/templates/named.conf.local.j2
+++ b/roles/simple_bind/templates/named.conf.local.j2
@@ -30,6 +30,18 @@ view {{ view.name }} {
 {% if view.get('allow_recursion') is not none %}
   allow-recursion {{ arg_list(view.allow_recursion, indent=2) }};
 {% endif %}
+{% for zone in simple_bind__primary_zones or [] %}
+{% if in_view(zone, view) %}
+
+  zone "{{ zone.zone }}" {
+    type {{ _sbind_term.primary }};
+    file {{ arg_path(_sbind_confdir, view.name, 'db.' + zone.zone) }};
+{% for extra in zone.get('extra_conf') or [] %}
+    {{ extra }};
+{% endfor %}
+  };
+{% endif %}
+{% endfor %}
 {% for zone in simple_bind__forward_zones or [] %}
 {% if in_view(zone, view) %}
 

--- a/roles/simple_bind/templates/named.conf.local.j2
+++ b/roles/simple_bind/templates/named.conf.local.j2
@@ -1,29 +1,65 @@
-{% from 'macros.j2' import arg_bool, arg_list %}
+{% from 'macros.j2' import arg_bool, arg_list, arg_path %}
+{# #}
+{% set view_names = simple_bind__views | map(attribute='name') |
+  map('mandatory', 'missing view name') %}
+{# #}
+{% macro in_view(zone, view) %}
+{% set zone_view = zone.get('view') or 'default' %}
+{% set _ = ('ok' if zone_view in view_names) |
+  mandatory('invalid view: ' + zone_view) %}
+{{- zone_view == view.name or None -}}
+{% endmacro %}
 {# #}
 // {{ ansible_managed }}
+{% for view in simple_bind__views or [] %}
 
+view {{ view.name }} {
+  match-clients {{
+    arg_list(
+      view.match_clients | mandatory('missing match clients list'),
+      indent=2)
+  }};
+{% if view.get('allow_transfer') is not none %}
+  allow-transfer {{ arg_list(view.allow_transfer, indent=2) }};
+{% endif %}
+  recursion {{ arg_bool(view.get('recursion')) }};
+{% if view.get('allow_recursion') is not none %}
+  allow-recursion {{ arg_list(view.allow_recursion, indent=2) }};
+{% endif %}
 {% for zone in simple_bind__forward_zones or [] %}
-zone "{{ zone.zone }}" {
-  type forward;
-  forward {{ zone.forward | default('first') }};
-  forwarders {{ arg_list(zone.get('forwarders') or [], indent=2) }};
-  file "db.{{ zone.zone }}";
-{% for extra in zone.get('extra_conf') or [] %}
-  {{ extra }};
-{% endfor %}
-};
+{% if in_view(zone, view) %}
 
+  zone "{{ zone.zone }}" {
+    type forward;
+    forward {{ zone.forward | default('first') }};
+    forwarders {{ arg_list(zone.get('forwarders') or [], indent=4) }};
+    file "db.{{ zone.zone }}";
+{% for extra in zone.get('extra_conf') or [] %}
+    {{ extra }};
+{% endfor %}
+  };
+{% endif %}
 {% endfor %}
 {% for zone in simple_bind__secondary_zones or [] %}
-zone "{{ zone.zone }}" {
-  type {{ _sbind_term.secondary }};
-  {{ _sbind_term.primaries }} {{
-    arg_list(zone.get('primaries') or [], indent=2)
-  }};
-  file "db.{{ zone.zone }}";
-{% for extra in zone.get('extra_conf') or [] %}
-  {{ extra }};
-{% endfor %}
-};
+{% if in_view(zone, view) %}
 
+  zone "{{ zone.zone }}" {
+    type {{ _sbind_term.secondary }};
+    {{ _sbind_term.primaries }} {{
+      arg_list(zone.get('primaries') or [], indent=4)
+    }};
+    file "db.{{ zone.zone }}";
+{% for extra in zone.get('extra_conf') or [] %}
+    {{ extra }};
+{% endfor %}
+  };
+{% endif %}
+{% endfor %}
+{% if view.get('includes') %}
+
+{% for file in view.includes %}
+  include {{ arg_path(_sbind_confdir, file) }};
+{% endfor %}
+{% endif %}
+};
 {% endfor %}

--- a/roles/simple_bind/templates/named.conf.local.j2
+++ b/roles/simple_bind/templates/named.conf.local.j2
@@ -30,6 +30,14 @@ view {{ view.name }} {
 {% if view.get('allow_recursion') is not none %}
   allow-recursion {{ arg_list(view.allow_recursion, indent=2) }};
 {% endif %}
+{% for zone in simple_bind__in_view_zones or [] %}
+{% if in_view(zone, view) %}
+
+  zone "{{ zone.zone }}" {
+    in-view {{ zone.in_view | mandatory('missing target view') }};
+  };
+{% endif %}
+{% endfor %}
 {% for zone in simple_bind__primary_zones or [] %}
 {% if in_view(zone, view) %}
 

--- a/roles/simple_bind/templates/named.conf.local.j2
+++ b/roles/simple_bind/templates/named.conf.local.j2
@@ -11,6 +11,10 @@
 {% endmacro %}
 {# #}
 // {{ ansible_managed }}
+{% for acl, items in simple_bind__acls.items() or {} %}
+
+acl {{ acl }} {{ arg_list(items) }};
+{% endfor %}
 {% for view in simple_bind__views or [] %}
 
 view {{ view.name }} {

--- a/roles/simple_bind/templates/named.conf.options.j2
+++ b/roles/simple_bind/templates/named.conf.options.j2
@@ -1,33 +1,26 @@
+{% from 'macros.j2' import arg_list %}
+{% set opt = simple_bind__options or {} %}
 // {{ ansible_managed }}
-
-{% with -%}
-{%- set opt = simple_bind__options or {} -%}
 
 options {
   directory "/var/cache/bind";
   dnssec-validation auto;
-
 {% if opt.get('forwarders') %}
+
   forward {{ opt.get('forward') or 'first' }};
-  forwarders {
-{% for forwarder in opt.forwarders %}
-    {{ forwarder }};
-{% endfor %}
-  };
-{% endif -%}
-
-{% for section, sconf in _sbind_listen.items() -%}
+  forwarders {{ arg_list(opt.forwarders, indent=2) }};
+{% endif %}
+{% for section, sconf in _sbind_listen.items() %}
 {% set stmt = section | replace('_', '-') %}
-{% for item in sconf %}
 
-{%- if item %}
-  {{ stmt }} port {{ item.port }} { {{ item.match_list | join('; ') }}; };
-{% endif -%}
-{%- endfor -%}
-{%- endfor %}
+{% for item in sconf | select %}
+  {{ stmt }} port {{ item.port }} {{ arg_list(item.match_list, indent=2) }};
+{% endfor %}
+{% endfor %}
+{% if opt.get('extra_conf') %}
 
-{%- for extra in opt.get('extra_conf') or [] %}
+{% for extra in opt.extra_conf %}
   {{ extra }};
-{% endfor -%}
+{% endfor %}
+{% endif %}
 };
-{%- endwith %}

--- a/roles/simple_bind/vars/main.yaml
+++ b/roles/simple_bind/vars/main.yaml
@@ -60,3 +60,9 @@ _sbind_listen: |-
 
 _sbind_ports: |-
   {{ _sbind_listen.values() | sum(start=[]) | map(attribute='port') | unique }}
+
+_sbind_includes_always:
+  - /etc/bind/named.conf.options
+  - /etc/bind/named.conf.local
+_sbind_includes: |-
+  {{ _sbind_includes_always + (simple_bind__includes or []) }}

--- a/roles/simple_bind/vars/main.yaml
+++ b/roles/simple_bind/vars/main.yaml
@@ -84,9 +84,17 @@ _sbind_zone_files: |-
     ('ok' if src_type in ('template', 'file', 'string')) |
     mandatory('invalid source type: ' + src_type)
   %}
+  {% set tmplvars =
+    {
+      'ZONE': zone if zone.endswith('.') else zone + '.',
+      'VIEW': view,
+    } | combine(conf.get('template_vars') or {})
+  %}
   {% set content =
-    lookup('file', src, rstrip=false) if src_type == 'file' else
-    lookup('template', src) if src_type == 'template' else
+    lookup('file', src, rstrip=false)
+    if src_type == 'file' else
+    lookup('template', src, template_vars=tmplvars)
+    if src_type == 'template' else
     src
   %}
   {% set _ = result.append(dict(dest=dest, content=content)) %}

--- a/roles/simple_bind/vars/main.yaml
+++ b/roles/simple_bind/vars/main.yaml
@@ -85,7 +85,7 @@ _sbind_zone_files: |-
     mandatory('invalid source type: ' + src_type)
   %}
   {% set content =
-    lookup('file', src) if src_type == 'file' else
+    lookup('file', src, rstrip=false) if src_type == 'file' else
     lookup('template', src) if src_type == 'template' else
     src
   %}

--- a/roles/simple_bind/vars/main.yaml
+++ b/roles/simple_bind/vars/main.yaml
@@ -69,3 +69,34 @@ _sbind_includes_always:
   - named.conf.local
 _sbind_includes: |-
   {{ _sbind_includes_always + (simple_bind__includes or []) }}
+
+_sbind_zone_files: |-
+  {% set result = [] %}
+  {% for conf in simple_bind__primary_zones or [] %}
+  {% set zone = conf.zone | mandatory('missing zone name') %}
+  {% set view = conf.view | mandatory('missing view name') %}
+  {% set dest =
+    (_sbind_confdir, view, 'db.' + zone) | ansible.builtin.path_join
+  %}
+  {% set src = conf.src | mandatory('missing zone source') %}
+  {% set src_type = conf.get('src_type') or 'string' %}
+  {% set _ =
+    ('ok' if src_type in ('template', 'file', 'string')) |
+    mandatory('invalid source type: ' + src_type)
+  %}
+  {% set content =
+    lookup('file', src) if src_type == 'file' else
+    lookup('template', src) if src_type == 'template' else
+    src
+  %}
+  {% set _ = result.append(dict(dest=dest, content=content)) %}
+  {% endfor %}
+  {{- result -}}
+
+_sbind_zone_dirs: |-
+  {{
+    _sbind_zone_files |
+    map(attribute='dest') |
+    map('ansible.builtin.dirname') |
+    unique
+  }}

--- a/roles/simple_bind/vars/main.yaml
+++ b/roles/simple_bind/vars/main.yaml
@@ -36,6 +36,9 @@ _sbind_svcname: |-
 
 # Pre-process configuration options.
 
+_sbind_confdir: |-
+  {{ simple_bind__config_dir or '/etc/bind' }}
+
 _sbind_listen: |-
   {% set sections = ('listen_on', 'listen_on_v6') %}
   {% set result = dict(sections | zip(([], []))) %}
@@ -62,7 +65,7 @@ _sbind_ports: |-
   {{ _sbind_listen.values() | sum(start=[]) | map(attribute='port') | unique }}
 
 _sbind_includes_always:
-  - /etc/bind/named.conf.options
-  - /etc/bind/named.conf.local
+  - named.conf.options
+  - named.conf.local
 _sbind_includes: |-
   {{ _sbind_includes_always + (simple_bind__includes or []) }}


### PR DESCRIPTION
* simple_bind: use macros to reduce repetition
* simple_bind: do not hardcode zone includes
* simple_bind: allow relative includes and setting the conf dir
* simple_bind: add "views" support
* simple_bind: add "acl" support
* simple_bind: add support for primary zones
* simple_bind: add argument spec for validation and documentation
* simple_bind: support `in-view` zones
* simple_bind: do not trim whitespace in files
* simple_bind: allow passing extra vars for templating
* simple_bind: avoid conflicts with zones defined in multiple views