### PR TITLE
Reduce noise

### DIFF
--- a/roles/apache2/tasks/conf_fragment.yaml
+++ b/roles/apache2/tasks/conf_fragment.yaml
@@ -19,6 +19,8 @@
     owner: '{{ _a2_conffile_owner }}'
     group: '{{ _a2_conffile_group }}'
   notify: '{{ item.notify }}'
+  # Avoid failures in check mode.
+  ignore_errors: '{{ ansible_check_mode }}'
 
 - name: Run {{ item.ctlcmd }} {{ item.name }}
   ansible.builtin.command:

--- a/roles/apache2/tasks/main.yaml
+++ b/roles/apache2/tasks/main.yaml
@@ -12,7 +12,7 @@
     mode: '{{ _a2_logdirs_mode }}'
     owner: '{{ _a2_logdirs_owner or "root" }}'
     group: '{{ _a2_logdirs_group or "adm" }}'
-  with_items: '{{ _a2_logdirs }}'
+  loop: '{{ _a2_logdirs }}'
 
 - name: Install ports.conf
   ansible.builtin.template:
@@ -45,6 +45,8 @@
 - name: Install configuration fragments
   ansible.builtin.include_tasks: conf_fragment.yaml
   loop: '{{ _a2_fragments }}'
+  loop_control:
+    label: '{{ item.afile }}'
 
 - name: Start and enable service
   ansible.builtin.service:

--- a/roles/apache2/vars/main.yaml
+++ b/roles/apache2/vars/main.yaml
@@ -61,7 +61,7 @@ _a2_fragments: |-
 
   {% set present = state in ('present', 'enabled') %}
   {% set enabled = state == 'enabled' %}
-  {% set content = lookup('file', src) if src_type == 'file' else
+  {% set content = lookup('file', src, rstrip=false) if src_type == 'file' else
       lookup('template', src) if src_type == 'template' else
       src %}
   {% set ext = 'load' if kind == 'mod' else 'conf' %}

--- a/roles/apt/tasks/main.yaml
+++ b/roles/apt/tasks/main.yaml
@@ -22,6 +22,8 @@
     dest: /etc/apt/sources.list.d/{{ item.key }}.list
     mode: '0644'
   loop: '{{ apt__custom_sources | d({}) | dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
   when: item.value
   register: _apt_custom_sources
 
@@ -30,6 +32,8 @@
     path: /etc/apt/sources.list.d/{{ item.key }}.list
     state: absent
   loop: '{{ apt__custom_sources | d({}) | dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
   when: not item.value
   register: _apt_custom_sources_rm
 
@@ -41,6 +45,8 @@
     group: root
     mode: '0644'
   loop: '{{ apt__trusted_keys | d({}) | dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
   when: item.value
   register: _apt_trusted_keys
 
@@ -49,6 +55,8 @@
     path: /etc/apt/trusted.gpg.d/{{ item.key }}.gpg
     state: absent
   loop: '{{ apt__trusted_keys | d({}) | dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
   when: not item.value
   register: _apt_trusted_keys_rm
 
@@ -60,6 +68,8 @@
     group: root
     mode: '0644'
   loop: '{{ apt__custom_preferences | d({}) | dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
   when: item.value
   register: _apt_custom_preferences
 
@@ -68,6 +78,8 @@
     path: /etc/apt/preferences.d/{{ item.key }}
     state: absent
   loop: '{{ apt__custom_preferences | d({}) | dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
   when: not item.value
   register: _apt_custom_preferences_rm
 

--- a/roles/ferm/tasks/main.yaml
+++ b/roles/ferm/tasks/main.yaml
@@ -60,7 +60,9 @@
     group: adm
     mode: '0644'
   notify: _tina_reload_ferm
-  with_dict: '{{ ferm__services }}'
+  loop: '{{ ferm__services | ansible.builtin.dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
 
 - name: Find obsolete service config files  # noqa: risky-shell-pipe
   ansible.builtin.shell: >-
@@ -74,7 +76,7 @@
   ansible.builtin.file:
     path: /etc/ferm/ferm.d/svc-{{ item }}.conf
     state: absent
-  with_items: '{{ ferm__config_files.stdout_lines }}'
+  loop: '{{ ferm__config_files.stdout_lines }}'
   when: item not in ferm__services
   notify: _tina_reload_ferm
 
@@ -86,7 +88,9 @@
     group: adm
     mode: '0644'
   notify: _tina_reload_ferm
-  with_dict: '{{ ferm__custom_configs }}'
+  loop: '{{ ferm__custom_configs | ansible.builtin.dict2items }}'
+  loop_control:
+    label: '{{ item.key }}'
 
 - name: Find obsolete custom config files  # noqa: risky-shell-pipe
   ansible.builtin.shell: >-
@@ -100,7 +104,7 @@
   ansible.builtin.file:
     path: /etc/ferm/ferm.d/custom-{{ item }}.conf
     state: absent
-  with_items: '{{ ferm__config_files.stdout_lines }}'
+  loop: '{{ ferm__config_files.stdout_lines }}'
   when: item not in ferm__custom_configs
   notify: _tina_reload_ferm
 

--- a/roles/mtail/tasks/main.yaml
+++ b/roles/mtail/tasks/main.yaml
@@ -23,7 +23,7 @@
     group: root
     mode: '0644'
   notify: _tina_restart_mtail
-  with_items: '{{ mtail__programs or [] }}'
+  loop: '{{ mtail__programs or [] }}'
 
 - name: Install ferm configuration
   ansible.builtin.include_role:

--- a/roles/prometheus/tasks/main.yaml
+++ b/roles/prometheus/tasks/main.yaml
@@ -31,7 +31,7 @@
     mode: '0644'
     validate: /usr/bin/promtool check rules %s
   notify: _tina_reload_prometheus
-  with_items: '{{ prometheus__rules }}'
+  loop: '{{ prometheus__rules }}'
   when: not item.endswith('.j2')
 
 - name: Install rules templates
@@ -48,7 +48,7 @@
     mode: '0644'
     validate: /usr/bin/promtool check rules %s
   notify: _tina_reload_prometheus
-  with_items: '{{ prometheus__rules }}'
+  loop: '{{ prometheus__rules }}'
   when: item.endswith('.j2')
 
 - name: Configure prometheus

--- a/roles/simple_bind/handlers/main.yaml
+++ b/roles/simple_bind/handlers/main.yaml
@@ -5,13 +5,19 @@
     cmd: named-checkconf
     chdir: '{{ _sbind_confdir }}'
   changed_when: false
+  # Do not run in check mode, as the package might not be available.
+  when: not ansible_check_mode
 
 - name: _tina_reload_bind
   ansible.builtin.service:
     name: '{{ _sbind_svcname }}'
     state: reloaded
+  # Do not run in check mode, as the package might not be available.
+  when: not ansible_check_mode
 
 - name: _tina_reload_ferm
   ansible.builtin.service:
     name: ferm
     state: reloaded
+  # Do not run in check mode, as the package might not be available.
+  when: not ansible_check_mode

--- a/roles/simple_bind/meta/argument_specs.yml
+++ b/roles/simple_bind/meta/argument_specs.yml
@@ -29,14 +29,14 @@ argument_specs:
             elements: str
             default: []
 
-          listen_on: &listen_on
+          listen_on:
             description: IPv4 addresses on which to listen for DNS queries.
             type: list
             elements: dict
             default:
               - port: 53
                 match_list: [any]
-            options:
+            options: &listen_on_opts
               port:
                 description: Port number
                 type: int
@@ -47,8 +47,13 @@ argument_specs:
                 default: [any]
 
           listen_on_v6:
-            <<: *listen_on
             description: IPv6 addresses on which to listen for DNS queries.
+            type: list
+            elements: dict
+            default:
+              - port: 53
+                match_list: [any]
+            options: *listen_on_opts
 
           extra_conf: &extra_conf
             description:

--- a/roles/simple_bind/tasks/main.yaml
+++ b/roles/simple_bind/tasks/main.yaml
@@ -19,7 +19,7 @@
 - name: Install configuration files
   ansible.builtin.template:
     src: '{{ item }}.j2'
-    dest: '{{ _sbind_confdir }}/{{ item }}'
+    dest: '{{ (_sbind_confdir, item) | ansible.builtin.path_join }}'
     owner: root
     group: root
     mode: '0644'
@@ -27,6 +27,8 @@
     - named.conf
     - named.conf.options
     - named.conf.local
+  loop_control:
+    label: '{{ (_sbind_confdir, item) | ansible.builtin.path_join }}'
   notify:
     - _tina_validate_bind_conf
     - _tina_reload_bind
@@ -48,6 +50,8 @@
     group: root
     mode: '0644'
   loop: '{{ _sbind_zone_files }}'
+  loop_control:
+    label: '{{ item.dest }}'
   notify:
     - _tina_validate_bind_conf
     - _tina_reload_bind

--- a/roles/simple_bind/tasks/main.yaml
+++ b/roles/simple_bind/tasks/main.yaml
@@ -13,6 +13,8 @@
   changed_when: false
   # Run normally even in check mode.
   check_mode: false
+  # Ignore errors in check mode (package not installed usually).
+  ignore_errors: '{{ ansible_check_mode }}'
 
 - name: Install configuration files
   ansible.builtin.template:
@@ -70,3 +72,5 @@
     name: '{{ _sbind_svcname }}'
     state: started
     enabled: true
+  # Ignore errors in check mode (package not installed usually).
+  ignore_errors: '{{ ansible_check_mode }}'

--- a/roles/users/tasks/main.yaml
+++ b/roles/users/tasks/main.yaml
@@ -50,8 +50,8 @@
       authorized: '{{ _user.authorized | d([]) }}'
   loop: '{{ users__create_users or [] }}'
   loop_control:
+    label: '{{ _user.name }}'
     loop_var: _user
-  no_log: true
 
 - name: Set mail forwarding for root
   ansible.builtin.lineinfile:

--- a/roles/users/tasks/user.yaml
+++ b/roles/users/tasks/user.yaml
@@ -42,16 +42,43 @@
       }}"
     exclusive: true
 
+- name: '[{{ user.name }}] set-up user home: find files'
+  # Scan users__home_dir_templates only once and segment results to avoid
+  # unnecessary loop interations later.
+  ansible.builtin.set_fact:
+    _usr_home_dirs: |-
+      {{ _usr_home_allfiles_by_state.get('directory') or [] }}
+    _usr_home_files: |-
+      {{
+        (_usr_home_allfiles_by_state.get('file') or []) |
+        rejectattr('path', 'ansible.builtin.search', '.*\.j2$')
+      }}
+    _usr_home_templates: |-
+      {{
+        (_usr_home_allfiles_by_state.get('file') or []) |
+        selectattr('path', 'ansible.builtin.search', '.*\.j2$')
+      }}
+    _usr_home_links: |-
+      {{ _usr_home_allfiles_by_state.get('link') or [] }}
+  vars:
+    _usr_home_srcdir: |-
+      {{ (users__home_dir_templates, user.name) | ansible.builtin.path_join }}
+    _usr_home_allfiles_by_state: |-
+      {{
+        query('community.general.filetree', _usr_home_srcdir) |
+        groupby('state') | community.general.dict
+      }}
+
 - name: '[{{ user.name }}] set-up user home: directories'
   ansible.builtin.file:
-    path: '{{ user.home }}/{{ item.path }}'
+    path: '{{ (user.home, item.path) | ansible.builtin.path_join }}'
     mode: '{{ _usr_home_dmode }}'
     owner: '{{ user.name }}'
     group: '{{ user.name }}'
     state: directory
-  with_community.general.filetree: '{{
-    users__home_dir_templates }}/{{ user.name }}'
-  when: item.state == 'directory'
+  loop: '{{ _usr_home_dirs }}'
+  loop_control:
+    label: '{{ (user.home, item.path) | ansible.builtin.path_join }}'
 
 - name: '[{{ user.name }}] set-up user home: normal files'
   ansible.builtin.copy:
@@ -62,9 +89,9 @@
     mode: '{{ _usr_home_fmode }}'
     owner: '{{ user.name }}'
     group: '{{ user.name }}'
-  with_community.general.filetree: '{{
-    users__home_dir_templates }}/{{ user.name }}'
-  when: item.state == 'file' and not item.src.endswith('.j2')
+  loop: '{{ _usr_home_files }}'
+  loop_control:
+    label: '{{ (user.home, item.path) | ansible.builtin.path_join }}'
 
 - name: '[{{ user.name }}] set-up user home: templates'
   ansible.builtin.template:
@@ -75,9 +102,9 @@
     mode: '{{ _usr_home_fmode }}'
     owner: '{{ user.name }}'
     group: '{{ user.name }}'
-  with_community.general.filetree: '{{
-    users__home_dir_templates }}/{{ user.name }}'
-  when: item.state == 'file' and item.src.endswith('.j2')
+  loop: '{{ _usr_home_templates }}'
+  loop_control:
+    label: '{{ (user.home, item.path) | ansible.builtin.path_join }}'
 
 - name: '[{{ user.name }}] set-up user home: symlinks'
   ansible.builtin.file:
@@ -89,6 +116,6 @@
     state: link
     force: true
     follow: false
-  with_community.general.filetree: '{{
-    users__home_dir_templates }}/{{ user.name }}'
-  when: item.state == 'link'
+  loop: '{{ _usr_home_links }}'
+  loop_control:
+    label: '{{ (user.home, item.path) | ansible.builtin.path_join }}'


### PR DESCRIPTION
* simple_bind: avoid `duplicate key` warnings in arg spec
* simple_bind: ignore certain errors in check mode
* various: modernise loops and reduce log noise
  * Replace deprecated `with_*` keywords with `loop` and jinja expressions.
  * Reduce log noise by setting `loop_control.label`.
  * Filter data before looping to avoid unnecessary iterations (`users` role).