### PR TITLE
node_exporter: fix handling of null var [compat-2.19]

### DIFF
--- a/roles/prometheus_node_exporter/defaults/main.yaml
+++ b/roles/prometheus_node_exporter/defaults/main.yaml
@@ -7,7 +7,7 @@ node_exporter__disk_ignored_devs:
 node_exporter__fs_ignored_mounts: '^/(sys|proc|dev|run)($|/)'
 node_exporter__net_ignored_devs: '^lo$'
 node_exporter__enabled_collectors:
-node_exporter__extra_args:
+node_exporter__extra_args: ~
 
 # If true, install ferm configuration file.
 node_exporter__install_ferm_svc: false

--- a/roles/prometheus_node_exporter/templates/default.j2
+++ b/roles/prometheus_node_exporter/templates/default.j2
@@ -35,4 +35,4 @@ ARGS=" \
   {{ _flag }}web.listen-address={{
     node_exporter__listen_addr ~ ':' ~ node_exporter__listen_port
   }} \
-  {{ node_exporter__extra_args }}"
+  {{ node_exporter__extra_args or '' }}"


### PR DESCRIPTION
A small 2.19 fix that I missed.